### PR TITLE
Fix PHP 8.4 deprecation: explicit nullable type required

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -9,7 +9,7 @@ interface Cache {
      * @param int $expiresIn
      * @return mixed
      */
-    public function get($key, callable $cached = null, $expiresIn = 0);
+    public function get($key, ?callable $cached = null, $expiresIn = 0);
 
     /**
      * @param string $key

--- a/src/Cache/Sqlite/Cache.php
+++ b/src/Cache/Sqlite/Cache.php
@@ -18,7 +18,7 @@ class Cache implements CacheInterface {
 
     private $functions;
 
-    public function __construct(array $config, string $namespace, ObjectifiedFunctions $functions = null) {
+    public function __construct(array $config, string $namespace, ?ObjectifiedFunctions $functions = null) {
         $this->cacheRoot = (string) $config['cacheRoot'];
         $this->name = (string) ($config['name'] ?? 'cache');
         $this->maxSize = (int) $config['maxSize'];
@@ -26,7 +26,7 @@ class Cache implements CacheInterface {
         $this->functions = $functions ?? new ObjectifiedFunctions();
     }
 
-    public function get($key, callable $fn = null, $expiresIn = 0) {
+    public function get($key, ?callable $fn = null, $expiresIn = 0) {
         return $this->getManager()->get($this->getKey($key), $fn, $expiresIn, $this->functions);
     }
 

--- a/src/Common/System.php
+++ b/src/Common/System.php
@@ -7,7 +7,7 @@ use Kibo\Phast\Exceptions\UndefinedObjectifiedFunction;
 class System {
     private $functions;
 
-    public function __construct(ObjectifiedFunctions $functions = null) {
+    public function __construct(?ObjectifiedFunctions $functions = null) {
         if ($functions === null) {
             $functions = new ObjectifiedFunctions();
         }

--- a/src/Exceptions/ItemNotFoundException.php
+++ b/src/Exceptions/ItemNotFoundException.php
@@ -11,7 +11,7 @@ class ItemNotFoundException extends \Exception {
      */
     private $url;
 
-    public function __construct($message = '', $code = 0, Throwable $previous = null, URL $failed = null) {
+    public function __construct($message = '', $code = 0, ?Throwable $previous = null, ?URL $failed = null) {
         parent::__construct($message, $code, $previous);
         $this->url = $failed;
     }

--- a/src/Filters/HTML/CSSInlining/Filter.php
+++ b/src/Filters/HTML/CSSInlining/Filter.php
@@ -320,7 +320,7 @@ class Filter extends BaseHTMLStreamFilter {
         return $elements;
     }
 
-    private function addIEFallback(URL $fallbackUrl = null, array $elements = null) {
+    private function addIEFallback(?URL $fallbackUrl = null, ?array $elements = null) {
         if ($fallbackUrl === null || !$elements) {
             return $elements;
         }

--- a/src/Filters/HTML/ImagesOptimizationService/ImageURLRewriter.php
+++ b/src/Filters/HTML/ImagesOptimizationService/ImageURLRewriter.php
@@ -79,7 +79,7 @@ class ImageURLRewriter {
      * @param bool $mustExist
      * @return string
      */
-    public function rewriteUrl($url, URL $baseUrl = null, array $params = [], $mustExist = false) {
+    public function rewriteUrl($url, ?URL $baseUrl = null, array $params = [], $mustExist = false) {
         if (strpos($url, '#') === 0) {
             return $url;
         }
@@ -171,7 +171,7 @@ class ImageURLRewriter {
      * @param URL|null $baseUrl
      * @return URL|null
      */
-    private function makeURLAbsoluteToBase($url, URL $baseUrl = null) {
+    private function makeURLAbsoluteToBase($url, ?URL $baseUrl = null) {
         $url = trim($url);
         if (!$url || substr($url, 0, 5) === 'data:') {
             return null;

--- a/src/Filters/HTML/ScriptsProxyService/Filter.php
+++ b/src/Filters/HTML/ScriptsProxyService/Filter.php
@@ -51,7 +51,7 @@ class Filter extends BaseHTMLStreamFilter {
         ServiceSignature $signature,
         LocalRetriever $retriever,
         TokenRefMaker $tokenRefMaker,
-        ObjectifiedFunctions $functions = null
+        ?ObjectifiedFunctions $functions = null
     ) {
         $this->config = $config;
         $this->signature = $signature;

--- a/src/Filters/Image/ImageImplementations/DefaultImage.php
+++ b/src/Filters/Image/ImageImplementations/DefaultImage.php
@@ -36,7 +36,7 @@ class DefaultImage extends BaseImage implements Image {
      */
     private $funcs;
 
-    public function __construct(URL $imageURL, Retriever $retriever, ObjectifiedFunctions $funcs = null) {
+    public function __construct(URL $imageURL, Retriever $retriever, ?ObjectifiedFunctions $funcs = null) {
         $this->imageURL = $imageURL;
         $this->retriever = $retriever;
         $this->funcs = is_null($funcs) ? new ObjectifiedFunctions() : $funcs;

--- a/src/Logging/LogWriters/PHPError/Writer.php
+++ b/src/Logging/LogWriters/PHPError/Writer.php
@@ -23,7 +23,7 @@ class Writer extends BaseLogWriter {
      * @param array $config
      * @param ObjectifiedFunctions $funcs
      */
-    public function __construct(array $config, ObjectifiedFunctions $funcs = null) {
+    public function __construct(array $config, ?ObjectifiedFunctions $funcs = null) {
         foreach (['messageType', 'destination', 'extraHeaders'] as $field) {
             if (isset($config[$field])) {
                 $this->$field = $config[$field];

--- a/src/Logging/LogWriters/RotatingTextFile/Writer.php
+++ b/src/Logging/LogWriters/RotatingTextFile/Writer.php
@@ -23,7 +23,7 @@ class Writer extends BaseLogWriter {
      * @param array $config
      * @param ?ObjectifiedFunctions $funcs
      */
-    public function __construct(array $config, ObjectifiedFunctions $funcs = null) {
+    public function __construct(array $config, ?ObjectifiedFunctions $funcs = null) {
         if (isset($config['path'])) {
             $this->path = (string) $config['path'];
         }

--- a/src/Logging/Logger.php
+++ b/src/Logging/Logger.php
@@ -24,7 +24,7 @@ class Logger {
      * Logger constructor.
      * @param LogWriter $writer
      */
-    public function __construct(LogWriter $writer, ObjectifiedFunctions $functions = null) {
+    public function __construct(LogWriter $writer, ?ObjectifiedFunctions $functions = null) {
         $this->writer = $writer;
         $this->functions = is_null($functions) ? new ObjectifiedFunctions() : $functions;
     }

--- a/src/PhastServices.php
+++ b/src/PhastServices.php
@@ -17,7 +17,7 @@ class PhastServices {
     /**
      * @param callable|null $getConfig
      */
-    public static function serve(callable $getConfig = null) {
+    public static function serve(?callable $getConfig = null) {
         $httpRequest = Request::fromGlobals();
 
         if ($httpRequest->getHeader('CDN-Loop')
@@ -131,7 +131,7 @@ class PhastServices {
         Request $request,
         Response $response,
         array $config,
-        ObjectifiedFunctions $funcs = null
+        ?ObjectifiedFunctions $funcs = null
     ) {
         if (is_null($funcs)) {
             $funcs = new ObjectifiedFunctions();

--- a/src/Retrievers/CachingRetriever.php
+++ b/src/Retrievers/CachingRetriever.php
@@ -27,7 +27,7 @@ class CachingRetriever implements Retriever {
      * @param Cache $cache
      * @param int $defaultCacheTime
      */
-    public function __construct(Cache $cache, Retriever $retriever = null, $defaultCacheTime = 0) {
+    public function __construct(Cache $cache, ?Retriever $retriever = null, $defaultCacheTime = 0) {
         $this->cache = $cache;
         $this->retriever = $retriever;
     }

--- a/src/Retrievers/LocalRetriever.php
+++ b/src/Retrievers/LocalRetriever.php
@@ -22,7 +22,7 @@ class LocalRetriever implements Retriever {
      * @param array $map
      * @param ObjectifiedFunctions|null $functions
      */
-    public function __construct(array $map, ObjectifiedFunctions $functions = null) {
+    public function __construct(array $map, ?ObjectifiedFunctions $functions = null) {
         $this->map = $map;
         if ($functions) {
             $this->funcs = $functions;

--- a/src/Retrievers/PostDataRetriever.php
+++ b/src/Retrievers/PostDataRetriever.php
@@ -18,7 +18,7 @@ class PostDataRetriever implements Retriever {
      * PostDataRetriever constructor.
      * @param ObjectifiedFunctions $funcs
      */
-    public function __construct(ObjectifiedFunctions $funcs = null) {
+    public function __construct(?ObjectifiedFunctions $funcs = null) {
         $this->funcs = is_null($funcs) ? new ObjectifiedFunctions() : $funcs;
     }
 

--- a/src/ValueObjects/PhastJavaScript.php
+++ b/src/ValueObjects/PhastJavaScript.php
@@ -43,7 +43,7 @@ class PhastJavaScript {
      * @param string $filename
      * @param ObjectifiedFunctions|null $funcs
      */
-    public static function fromFile($filename, ObjectifiedFunctions $funcs = null) {
+    public static function fromFile($filename, ?ObjectifiedFunctions $funcs = null) {
         $funcs = $funcs ? $funcs : new ObjectifiedFunctions();
         $contents = $funcs->file_get_contents($filename);
         if ($contents === false) {

--- a/test/php/Filters/Service/CachingServiceFilterTest.php
+++ b/test/php/Filters/Service/CachingServiceFilterTest.php
@@ -35,7 +35,7 @@ class CachingServiceFilterTest extends TestCase {
 
         $cache = $this->createMock(Cache::class);
         $cache->method('get')
-            ->willReturnCallback(function ($key, callable $cb = null, $ttl = 0) {
+            ->willReturnCallback(function ($key, ?callable $cb = null, $ttl = 0) {
                 if (!isset($this->cachedData[$key])) {
                     if ($cb) {
                         $data = $cb();

--- a/test/php/Services/Scripts/ServiceTest.php
+++ b/test/php/Services/Scripts/ServiceTest.php
@@ -46,7 +46,7 @@ class ServiceTest extends TestCase {
         $this->retriever = $this->createMock(Retriever::class);
         $this->filter = $this->createMock(ServiceFilter::class);
         $this->filter->method('apply')
-            ->willReturnCallback(function (Resource $resource, array $params = null) {
+            ->willReturnCallback(function (Resource $resource, ?array $params = null) {
                 if (isset($this->returnResource)) {
                     return $this->returnResource;
                 }


### PR DESCRIPTION
## **Description**

This PR resolves the PHP 8.4 deprecation warning: *"Implicitly marking parameter as nullable is deprecated"*.

I have updated function signatures where a type hint is used with a `null` default value to use the explicit `?Type` syntax.

### **Compatibility**

* **PHP 7.4+ Compatible:** Uses nullable syntax supported since PHP 7.1.
* **Syntax Only:** No changes to logic or functionality.
* **Future-proof:** Ensures clean logs for users on PHP 8.4+ without breaking older environments.